### PR TITLE
Change chevron behavior to be "normal"

### DIFF
--- a/scripts/components/CourseTree.jsx
+++ b/scripts/components/CourseTree.jsx
@@ -49,7 +49,7 @@ var CourseTree = React.createClass({
         var subEcts = CourseCtrl.addedEcts(course);
         var isSearching = this.props.search.length > 0;
 
-        var chevronClass = 'fa fa-chevron-' + ((this.state.childVisible) ? 'right' : 'down');
+        var chevronClass = 'fa fa-chevron-' + ((this.state.childVisible) ? 'down' : 'right');
         var chevron = (course.children.length && !isSearching) ? <i key={1} className={chevronClass}/> : null;
 
         var badge = <Badge key={2}>EC {subEcts}/{totalEcts}</Badge>;


### PR DESCRIPTION
Usually pointing to the right means closed; down means opened (or am I just confused?).
